### PR TITLE
Quartus compatibility

### DIFF
--- a/src/jtagreg.sv
+++ b/src/jtagreg.sv
@@ -48,8 +48,9 @@ module jtagreg
     );
 
     generate
-        for (genvar i=1;i<JTAGREGSIZE-1;i=i+1)
-        begin
+        genvar i;
+        for (i=1;i<JTAGREGSIZE-1;i=i+1)
+        begin : GEN_BSCELL
             bscell reg_bit_mid
               (
                 .clk_i(clk_i),


### PR DESCRIPTION
In reference to: pulp-platform/pulpissimo#78

Fixed errors:

- `src/jtagreg.sv`: [unnamed loop generate, genvar inside for loop definition](https://marekpikula.github.io/quartus-sv-gotchas/Intel%20Quartus%20SystemVerilog%20gotchas.html#274-loop-generate-constructs-3)