### PR TITLE
Fix wrong assignments?

### DIFF
--- a/src/tap_top.v
+++ b/src/tap_top.v
@@ -542,9 +542,9 @@ begin
         `REG1:              tdo_comb = memory_out_i;      // REG1
         `REG2:              tdo_comb = fifo_out_i;        // REG2
         `REG3:              tdo_comb = confreg_out_i;     // REG3
-        `REG_CLK_BYP:       tdo_comb = confreg_out_i;     // REG4
-        `REG_OBSERV:        tdo_comb = clk_byp_out_i;     // REG5
-        `BYPASS:            tdo_comb = bypassed_tdo;     // BYPASS
+        `REG_CLK_BYP:       tdo_comb = clk_byp_out_i;     // REG4
+        `REG_OBSERV:        tdo_comb = observ_out_i;      // REG5
+        `BYPASS:            tdo_comb = bypassed_tdo;      // BYPASS
         default:            tdo_comb = bypassed_tdo;      // BYPASS instruction
       endcase
     end


### PR DESCRIPTION
@igorloi could you briefly check whether the changes introduced by your commit 2c2c2269d8bacc2b6905ea579b7272b150064f23 are correct. Just looking at the semantic structure it seems to me like there is an error in the wiring of the observ_out_i and the clk_byp_out_i signal...